### PR TITLE
*+ cosmic_fengine use remotepcie if uri provided

### DIFF
--- a/sw/control_sw/scripts/cosmic_feng_init.py
+++ b/sw/control_sw/scripts/cosmic_feng_init.py
@@ -29,6 +29,8 @@ def main():
                         help='Program FPGAs with the pre-loaded fpg file')
     parser.add_argument('-f','--fpgfile', type=str, default=DEFAULT_FPGFILE,
                         help='Path to .fpg firmware file')
+    parser.add_argument('-R','--remote', type=str, default=None,
+                        help='URI to remote REST server')
     parser.add_argument('fpga_id', type=int, default=0,
                         help='FPGA pcie card ID')
     parser.add_argument('pipeline_id', type=int, default=0,
@@ -37,7 +39,10 @@ def main():
 
     hostname = 'pcie%d' % args.fpga_id
 
-    f = cosmic_fengine.CosmicFengine(hostname, args.fpgfile, pipeline_id=args.pipeline_id)
+    f = cosmic_fengine.CosmicFengine(
+        hostname, args.fpgfile, pipeline_id=args.pipeline_id,
+        remote_uri=args.remote
+    )
 
     f.cold_start_from_config(
             args.outputconfig,

--- a/sw/control_sw/src/cosmic_fengine.py
+++ b/sw/control_sw/src/cosmic_fengine.py
@@ -54,7 +54,7 @@ class CosmicFengine():
     :type logger: logging.Logger
 
     """
-    def __init__(self, host, fpgfile, pipeline_id=0, neths=1, logger=None):
+    def __init__(self, host, fpgfile, pipeline_id=0, neths=1, logger=None, remote_uri=None):
         self.hostname = host #: hostname of the F-Engine's host SNAP2 board
         self.pipeline_id = pipeline_id
         self.fpgfile = fpgfile
@@ -62,10 +62,22 @@ class CosmicFengine():
         #: Python Logger instance
         self.logger = logger or helpers.add_default_log_handlers(logging.getLogger(__name__ + ":%s" % (host)))
         #: Underlying CasperFpga control instance
-        self._cfpga = casperfpga.CasperFpga(
-                        host=self.hostname,
-                        transport=casperfpga.LocalPcieTransport,
-                    )
+        if remote_uri is None:
+            self._cfpga = casperfpga.CasperFpga(
+                            host=self.hostname,
+                            transport=casperfpga.LocalPcieTransport,
+                        )
+        else:
+            self._cfpga = casperfpga.CasperFpga(
+                            host=self.hostname,
+                            uri=remote_uri,
+                            transport=casperfpga.RemotePcieTransport,
+                        )
+        
+            remotepcie = self._cfpga.transport
+            if True: #remotepcie.is_connected(0, 0) and not remotepcie.is_programmed():
+                print("Programmed Successfully:", remotepcie.upload_to_ram_and_program(fpgfile))
+
         try:
             self._cfpga.get_system_information(fpgfile)
         except:


### PR DESCRIPTION
Should be backwards compatible :+1:
Requires [RemotePCIeTransport](https://github.com/realtimeradio/casperfpga/pull/1)