### PR TITLE
* cosmic_fengine hostname is parsed for pci ID

### DIFF
--- a/sw/control_sw/scripts/cosmic_feng_init.py
+++ b/sw/control_sw/scripts/cosmic_feng_init.py
@@ -31,13 +31,13 @@ def main():
                         help='Path to .fpg firmware file')
     parser.add_argument('-R','--remote', type=str, default=None,
                         help='URI to remote REST server')
-    parser.add_argument('fpga_id', type=int, default=0,
+    parser.add_argument('fpga_id', type=str, default=0,
                         help='FPGA pcie card ID')
     parser.add_argument('pipeline_id', type=int, default=0,
                         help='Pipeline ID on chosen FPGA card')
     args = parser.parse_args()
 
-    hostname = 'pcie%d' % args.fpga_id
+    hostname = 'pcie%s' % args.fpga_id
 
     f = cosmic_fengine.CosmicFengine(
         hostname, args.fpgfile, pipeline_id=args.pipeline_id,

--- a/sw/control_sw/src/cosmic_fengine.py
+++ b/sw/control_sw/src/cosmic_fengine.py
@@ -59,6 +59,8 @@ class CosmicFengine():
     """
     def __init__(self, host, fpgfile, fpga_id=0, pipeline_id=0, neths=1, logger=None, remote_uri=None):
         self.hostname = host #: hostname of the F-Engine's host SNAP2 board
+        self.pci_id = host[4:] if host.startswith('pcie') else None
+        self.instance_id = int(host[4:]) if host.startswith('xdma') else 0
         self.pipeline_id = pipeline_id
         self.fpgfile = fpgfile
         self.neths = neths
@@ -68,12 +70,15 @@ class CosmicFengine():
         if remote_uri is None:
             self._cfpga = casperfpga.CasperFpga(
                             host=self.hostname,
+                            instance_id=self.instance_id,
                             transport=casperfpga.LocalPcieTransport,
                             instance_id=fpga_id,
                         )
         else:
             self._cfpga = casperfpga.CasperFpga(
                             host=self.hostname,
+                            pci_id=self.pci_id,
+                            instance_id=self.instance_id,
                             uri=remote_uri,
                             transport=casperfpga.RemotePcieTransport,
                             instance_id=fpga_id,


### PR DESCRIPTION
- https://github.com/realtimeradio/casperfpga/issues/2

Related to https://github.com/realtimeradio/casperfpga/pull/3