### PR TITLE
RemoteObjects and minor production changes

### DIFF
--- a/sw/control_sw/requirements.txt
+++ b/sw/control_sw/requirements.txt
@@ -7,3 +7,4 @@ pyyaml
 #python3-tk
 termcolor
 progressbar
+remoteobjects

--- a/sw/control_sw/scripts/rest_serve_remoteobjects.py
+++ b/sw/control_sw/scripts/rest_serve_remoteobjects.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python
+from flask import Flask
+from flask_restful import Resource
+from casperfpga import LocalPcieTransport
+from remoteobjects.server import addRemoteObjectResources, ObjectRegistry
+import argparse
+from cosmic_f import cosmic_fengine
+
+PCIE_XDMA_DICT = None
+
+app = Flask(__name__)
+flask_api, object_registry = addRemoteObjectResources(
+    app,
+    [
+        cosmic_fengine.CosmicFengine
+    ]
+)
+
+class RestTransport_PciXdmaMap(Resource):
+    def get(self):
+        return {
+            'pci_xdma_id_map': PCIE_XDMA_DICT
+        }, 200
+
+flask_api.add_resource(RestTransport_PciXdmaMap, '/PciXdmaMap')
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(
+        description=('Initialize a REST server exposing local PCIe FPGA device'
+        'python objects as remoteobjects.')
+    )
+    parser.add_argument('--fpgfile', '-f', type=str,
+        default='/home/cosmic/dev/vla-dev/pr_templates/adm_4x100g_pr_template_test/outputs/adm_4x100g_pr_template_test_2022-02-03_1951.fpg',
+        help='Path to the initial fpg file that the PCI devices are programmed with.'
+    )
+    parser.add_argument('--program', '-p', action='store_true',
+        help='Program the PCI devices with fpgfile.'
+    )
+    args = parser.parse_args()
+
+    PCIE_XDMA_DICT = LocalPcieTransport.get_pcie_xdma_map()
+    for (pcie_id, xdma_id) in PCIE_XDMA_DICT.items():
+        for pipeline_id in range(2):
+            pcie_id_string = f'pcie{pcie_id}'
+            obj_id = object_registry.register_new_object(
+                'CosmicFengine',
+                {# __init__ args
+                    'host': pcie_id_string,
+                    'fpgfile': args.fpgfile,
+                    'pipeline_id': pipeline_id
+                }
+            )
+            object_id = f'{pcie_id_string}_{pipeline_id}'
+            object_registry.obj_set_id(obj_id, object_id)
+            print(f'Registered CosmicFengine `{object_id}`...')
+            if pipeline_id == 0 and args.program:
+                object_registry.get_registered_object(object_id)._cfpga.upload_to_ram_and_program(args.fpgfile)
+                print(f'\tProgrammed `{object_id}`...')
+
+    app.run(host='0.0.0.0', port=6000, debug=False)

--- a/sw/control_sw/src/blocks/eth.py
+++ b/sw/control_sw/src/blocks/eth.py
@@ -132,6 +132,12 @@ class Eth(Block):
         Disable Ethernet transmission.
         """
         self.change_reg_bits('ctrl', 0, 1)
+    
+    def tx_enabled(self):
+        """
+        Ethernet transmission enabled.
+        """
+        return self.get_reg_bits('ctrl', 1)
 
     def initialize(self, read_only=False):
         """

--- a/sw/control_sw/src/blocks/pfb.py
+++ b/sw/control_sw/src/blocks/pfb.py
@@ -83,7 +83,7 @@ class Pfb(Block):
         if stats['overflow_count'] != 0:
             flags['overflow_count'] = FENG_WARNING
         fft_shift = self.get_fft_shift()
-        stats['fft_shift'] = '0b%s' % np.binary_repr(fft_shift, width=self.STAGES)
+        # stats['fft_shift'] = '0b%s' % np.binary_repr(fft_shift, width=self.STAGES)
         return stats, flags
 
     def sel_band(self, start_chan=0):

--- a/sw/control_sw/src/cosmic_fengine.py
+++ b/sw/control_sw/src/cosmic_fengine.py
@@ -29,6 +29,8 @@ from .blocks import chanreorder
 from .blocks import packetizer
 from .blocks import autocorr
 
+from remoteobjects.client import defineRemoteClass
+
 FENG_UDP_SOURCE_PORT = 10000
 MAC_BASE = 0x020203030400
 IP_BASE = (100 << 24) + (100 << 16) + (101 << 8) + 10
@@ -40,6 +42,19 @@ DEFAULT_FIRMWARE_TYPE = FIRMWARE_TYPE_8BIT
 DEFAULT_DTS_LANE_MAPS = [[0,1,3,2,4,5,7,6,8,9,11,10], [0,1,3,2,8,9,11,10,4,5,7,6]]
 
 class CosmicFengine():
+    def __new__(cls, host, fpgfile, pipeline_id=0, neths=1, logger=None, remote_uri=None, remoteobject_uri=None):
+        if remoteobject_uri is not None:
+            defineRemoteClass(
+                'CosmicFengine',
+                remoteobject_uri,
+                globals(),
+                delete_remote_on_del=False,
+                allowed_upload_extension_regex=r'\.fpg|\.yaml',
+                attribute_depth_allowance=1,
+            )
+            return CosmicFengineRemote(remote_object_id=f'{host}_{pipeline_id}')
+        return object.__new__(CosmicFengine)
+
     """
     A control class for COSMIC's F-Engine firmware.
 
@@ -58,6 +73,10 @@ class CosmicFengine():
         triggers the transport to be a RemotePcieTransport object.
     :type remote_uri: str
 
+    :param remoteobjects_uri: RemoteObjects host address, eg. `https://100.100.100.100:6000`. This 
+        causes self to be a CosmicFengineRemote instance.
+    :type remoteobjects_uri: str
+
     :param fpgfile: .fpg file for firmware to program (or already loaded)
     :type fpgfile: str
 
@@ -71,7 +90,7 @@ class CosmicFengine():
     :type logger: logging.Logger
 
     """
-    def __init__(self, host, fpgfile, pipeline_id=0, neths=1, logger=None, remote_uri=None):
+    def __init__(self, host, fpgfile, pipeline_id=0, neths=1, logger=None, remote_uri=None, remoteobject_uri=None):
         self.hostname = host #: hostname of the F-Engine's host SNAP2 board
         self.pipeline_id = pipeline_id
         self.fpgfile = fpgfile
@@ -335,6 +354,12 @@ class CosmicFengine():
                 else:
                     print('Block %s stats:' % blockname)
                     block.print_status(use_color=use_color, ignore_ok=ignore_ok)
+
+    """
+    Have set_delay on this level
+    """
+    def set_delay(self, stream, delay):
+        self.delay.set_delay(stream, delay)
 
     def set_equalization(self, eq_start_chan=100, eq_stop_chan=400, 
             start_chan=50, stop_chan=450, filter_ksize=21, target_rms=0.2):
@@ -709,7 +734,11 @@ class CosmicFengine():
         report of the channels' destination-IPs, as a json string.
         '''
         if not hasattr(self, 'packetizer'):
-            return '{}'
+            return '[]'
+        
+        if not any([eth.tx_enabled() for eth in self.eths]):
+            return '[]'
+
         headers = self.packetizer._read_headers()
         
         packet_dest_ips = []


### PR DESCRIPTION
Succinct commit messages cover what is done.

Primarily the addition of `remoteobjects_uri` to the constructor triggers returning a remoteobjects CosmicFengineRemote instance instead of a CosmicFengine instance...