### PR TITLE
%* move CosmicFengineRemote to separate package

### DIFF
--- a/sw/control_remote_sw/setup.py
+++ b/sw/control_remote_sw/setup.py
@@ -1,0 +1,36 @@
+from distutils.core import setup
+import glob
+import os
+
+ver = '0.0.1'
+try:
+    import subprocess
+    ver = ver + '-' + subprocess.check_output(['git', 'describe', '--abbrev=8', '--always', '--dirty', '--tags']).decode().strip()
+    print('Version is: %s' % ver)
+except:
+    print('Couldn\'t get version from git. Defaulting to %s' % ver)
+
+# Generate a __version__.py file with this version in it
+here = os.path.abspath(os.path.dirname(__file__))
+with open(os.path.join(here, 'src', '__version__.py'), 'w') as fh:
+    fh.write('__version__ = "%s"' % ver)
+
+setup(name='cosmic_f_remote',
+      version='%s' % ver,
+      description='Python libraries to control remoteobjects served COSMIC F-Engines',
+      author='Ross Donnachie',
+      author_email='code@radonn.co.za',
+      url='https://github.com/realtimeradio/vla-dev',
+      provides=['cosmic_f_remote'],
+      packages=['cosmic_f_remote'],
+      package_dir={'cosmic_f_remote' : 'src'},
+    #   scripts=glob.glob('scripts/*.py'),
+      )
+
+if ver.endswith("dirty"):
+    print("***************************************************")
+    print("* You are installing from a dirty git repository. *")
+    print("*          One day you will regret this.          *")
+    print("*                                                 *")
+    print("*      Consider cleaning up and reinstalling.     *")
+    print("***************************************************")

--- a/sw/control_remote_sw/src/__init__.py
+++ b/sw/control_remote_sw/src/__init__.py
@@ -1,0 +1,3 @@
+from .__version__ import __version__
+
+from .cosmic_fengine import CosmicFengine

--- a/sw/control_remote_sw/src/__version__.py
+++ b/sw/control_remote_sw/src/__version__.py
@@ -1,0 +1,1 @@
+__version__ = "0.0.1-8c2f9b82-dirty"

--- a/sw/control_remote_sw/src/cosmic_fengine.py
+++ b/sw/control_remote_sw/src/cosmic_fengine.py
@@ -1,7 +1,7 @@
 from remoteobjects.client import defineRemoteClass
 
 class CosmicFengine():
-    def __new__(cls, host, remoteobject_uri, neths=1, logger=None):
+    def __new__(cls, host, remoteobject_uri, pipeline_id=0, attribute_depth_allowance=1):
         """
         This is prioritised constructor method. If remoteobject_uri is specified, a CosmicFengineRemote class instance
         is returned instead of the expected `CosmicFengine` instance. In the latter case, the `__init__` method is
@@ -13,6 +13,6 @@ class CosmicFengine():
 						globals(),
 						delete_remote_on_del=False,
 						allowed_upload_extension_regex=r'\.fpg|\.yaml',
-						attribute_depth_allowance=1,
+						attribute_depth_allowance=attribute_depth_allowance
 				)
 				return CosmicFengineRemote(remote_object_id=f'{host}_{pipeline_id}')

--- a/sw/control_remote_sw/src/cosmic_fengine.py
+++ b/sw/control_remote_sw/src/cosmic_fengine.py
@@ -7,12 +7,13 @@ class CosmicFengine():
         is returned instead of the expected `CosmicFengine` instance. In the latter case, the `__init__` method is
         invoked with all the same arguments.
         """
-				defineRemoteClass(
-						'CosmicFengine',
-						remoteobject_uri,
-						globals(),
-						delete_remote_on_del=False,
-						allowed_upload_extension_regex=r'\.fpg|\.yaml',
-						attribute_depth_allowance=attribute_depth_allowance
-				)
-				return CosmicFengineRemote(remote_object_id=f'{host}_{pipeline_id}')
+        definition_dict={}
+        defineRemoteClass(
+                'CosmicFengine',
+                remoteobject_uri,
+                definition_dict,
+                delete_remote_on_del=False,
+                allowed_upload_extension_regex=r'\.fpg|\.yaml',
+                attribute_depth_allowance=attribute_depth_allowance
+        )
+        return definition_dict['CosmicFengineRemote'](remote_object_id=f'{host}_{pipeline_id}')

--- a/sw/control_remote_sw/src/cosmic_fengine.py
+++ b/sw/control_remote_sw/src/cosmic_fengine.py
@@ -1,0 +1,18 @@
+from remoteobjects.client import defineRemoteClass
+
+class CosmicFengine():
+    def __new__(cls, host, remoteobject_uri, neths=1, logger=None):
+        """
+        This is prioritised constructor method. If remoteobject_uri is specified, a CosmicFengineRemote class instance
+        is returned instead of the expected `CosmicFengine` instance. In the latter case, the `__init__` method is
+        invoked with all the same arguments.
+        """
+				defineRemoteClass(
+						'CosmicFengine',
+						remoteobject_uri,
+						globals(),
+						delete_remote_on_del=False,
+						allowed_upload_extension_regex=r'\.fpg|\.yaml',
+						attribute_depth_allowance=1,
+				)
+				return CosmicFengineRemote(remote_object_id=f'{host}_{pipeline_id}')

--- a/sw/control_sw/src/cosmic_fengine.py
+++ b/sw/control_sw/src/cosmic_fengine.py
@@ -29,8 +29,6 @@ from .blocks import chanreorder
 from .blocks import packetizer
 from .blocks import autocorr
 
-from remoteobjects.client import defineRemoteClass
-
 FENG_UDP_SOURCE_PORT = 10000
 MAC_BASE = 0x020203030400
 IP_BASE = (100 << 24) + (100 << 16) + (101 << 8) + 10
@@ -78,24 +76,6 @@ class CosmicFengine():
     :type logger: logging.Logger
 
     """
-
-    def __new__(cls, host, fpgfile=None, pipeline_id=0, neths=1, logger=None, remote_uri=None, remoteobject_uri=None):
-        """
-        This is prioritised constructor method. If remoteobject_uri is specified, a CosmicFengineRemote class instance
-        is returned instead of the expected `CosmicFengine` instance. In the latter case, the `__init__` method is
-        invoked with all the same arguments.
-        """
-        if remoteobject_uri is not None:
-            defineRemoteClass(
-                'CosmicFengine',
-                remoteobject_uri,
-                globals(),
-                delete_remote_on_del=False,
-                allowed_upload_extension_regex=r'\.fpg|\.yaml',
-                attribute_depth_allowance=1,
-            )
-            return CosmicFengineRemote(remote_object_id=f'{host}_{pipeline_id}')
-        return object.__new__(CosmicFengine)
 
     def __init__(self, host, fpgfile, pipeline_id=0, neths=1, logger=None, remote_uri=None, remoteobject_uri=None):
         self.hostname = host #: hostname of the F-Engine's host SNAP2 board


### PR DESCRIPTION
- cosmic_f_remote package provides drop in CosmicFengine replacement, only always returns remoteobjects client-class