### PR TITLE
Merge in improvements to delay tracking

### DIFF
--- a/software/control_sw/scripts/rest_serve_remoteobjects.py
+++ b/software/control_sw/scripts/rest_serve_remoteobjects.py
@@ -56,7 +56,7 @@ if __name__ == '__main__':
     parser.add_argument('--program', '-p', action='store_true',
         help='Program the PCI devices with fpgfile.'
     )
-    parser.add_argument('--redis-host', type=str, default='cosmic-head',
+    parser.add_argument('--redis-host', type=str, default='redishost',
         help='Redis server host address.'
     )
     parser.add_argument('--redis-port', type=int, default=6379,

--- a/software/control_sw/scripts/rest_serve_remoteobjects.py
+++ b/software/control_sw/scripts/rest_serve_remoteobjects.py
@@ -56,6 +56,12 @@ if __name__ == '__main__':
     parser.add_argument('--program', '-p', action='store_true',
         help='Program the PCI devices with fpgfile.'
     )
+    parser.add_argument('--redis-host', type=str, default='cosmic-head',
+        help='Redis server host address.'
+    )
+    parser.add_argument('--redis-port', type=int, default=6379,
+        help='Redis server host port.'
+    )
     args = parser.parse_args()
 
     PCIE_XDMA_DICT = LocalPcieTransport.get_pcie_xdma_map()
@@ -72,7 +78,9 @@ if __name__ == '__main__':
                 {# __init__ args
                     'host': pcie_id_string,
                     'fpgfile': args.fpgfile,
-                    'pipeline_id': pipeline_id
+                    'pipeline_id': pipeline_id,
+                    'redis_host': args.redis_host,
+                    'redis_port': args.redis_port,
                 }
             )
             object_id = f'{pcie_id_string}_{pipeline_id}'

--- a/software/control_sw/src/blocks/delay.py
+++ b/software/control_sw/src/blocks/delay.py
@@ -21,7 +21,8 @@ class Delay(Block):
 
     """
     MIN_DELAY = 0 #: minimum delay allowed
-    DEFAULT_MAX_DELAY = 2**18 - 1
+    _BP = 18
+    DEFAULT_MAX_DELAY = 2**_BP - 1
     def __init__(self, host, name, n_streams=64, logger=None):
         super(Delay, self).__init__(host, name, logger)
         self.timer = TimedPulse(host, name+"_timing", logger)
@@ -135,13 +136,13 @@ class Delay(Block):
         :type stream: int
 
         :return: Currently loaded delay, in ADC samples
-        :rtype: int
+        :rtype: int, scale
 
         """
         if stream > self.n_streams:
             self._error('Tried to get delay for stream %d > n_streams (%d)' % (stream, self.n_streams))
         delay_reg = 'delay%d_loaded' % stream
-        return self.read_uint(delay_reg)
+        return self.read_uint(delay_reg), 2**self._BP
 
     def initialize(self, read_only=False):
         """

--- a/software/control_sw/src/blocks/delay.py
+++ b/software/control_sw/src/blocks/delay.py
@@ -21,8 +21,7 @@ class Delay(Block):
 
     """
     MIN_DELAY = 0 #: minimum delay allowed
-    _BP = 18
-    DEFAULT_MAX_DELAY = 2**_BP - 1
+    DEFAULT_MAX_DELAY = 2**18 - 1
     def __init__(self, host, name, n_streams=64, logger=None):
         super(Delay, self).__init__(host, name, logger)
         self.timer = TimedPulse(host, name+"_timing", logger)
@@ -136,13 +135,13 @@ class Delay(Block):
         :type stream: int
 
         :return: Currently loaded delay, in ADC samples
-        :rtype: int, scale
+        :rtype: int
 
         """
         if stream > self.n_streams:
             self._error('Tried to get delay for stream %d > n_streams (%d)' % (stream, self.n_streams))
         delay_reg = 'delay%d_loaded' % stream
-        return self.read_uint(delay_reg), 2**self._BP
+        return self.read_uint(delay_reg)
 
     def initialize(self, read_only=False):
         """

--- a/software/control_sw/src/blocks/fpga.py
+++ b/software/control_sw/src/blocks/fpga.py
@@ -77,6 +77,20 @@ class Fpga(Block):
         t = self.read_uint('version_timestamp')
         return t
 
+    def set_connected_antname(self, antname):
+        """
+        Set the connected antenna name.
+        :param antname: The antenna name.
+        :type antname: str
+        """
+        self.antname = antname
+
+    def get_connected_antname(self):
+        """
+        Fetch the connected antenna name.
+        """
+        return self.antname
+
     def is_programmed(self):
         """
         Lazy check to see if a board is programmed.
@@ -106,6 +120,8 @@ class Fpga(Block):
             - timestamp (str) : The current time, as an ISO format string.
 
             - host (str) : The host name of this board.
+
+            - antname (str) : The name of the antenna connected to this board.
 
             - sw_version (str) : The version string of the control software
               package. Flagged as warning if the version indicates a build
@@ -157,6 +173,7 @@ class Fpga(Block):
         stats['programmed'] = self.is_programmed()
         stats['timestamp'] = datetime.datetime.now().isoformat()
         stats['host'] = '%s:%s' % (self.server_hostname, self.host.host)
+        stats['antname'] = self.antname
         stats['sw_version'] = __version__
         if stats['programmed']:
             stats['fw_version'] = self.get_firmware_version()

--- a/software/control_sw/src/blocks/fpga.py
+++ b/software/control_sw/src/blocks/fpga.py
@@ -80,6 +80,7 @@ class Fpga(Block):
     def set_connected_antname(self, antname):
         """
         Set the connected antenna name.
+        
         :param antname: The antenna name.
         :type antname: str
         """
@@ -88,6 +89,9 @@ class Fpga(Block):
     def get_connected_antname(self):
         """
         Fetch the connected antenna name.
+
+        :return self.antname: The name of the connected antennna.
+        :rtype str:
         """
         return self.antname
 

--- a/software/control_sw/src/cosmic_fengine.py
+++ b/software/control_sw/src/cosmic_fengine.py
@@ -111,8 +111,6 @@ class CosmicFengine():
                 _, fpg_info = self._cfpga.transport.get_system_information_from_transport()
                 self._cfpga.get_system_information(filename=None, fpg_info=fpg_info)
             else:
-                if self.delay_tracking_thread.is_alive():
-                    self.stop_delay_tracking()
                 self._cfpga.upload_to_ram_and_program(fpgfile)
             
         if redis_host is None or redis_port is None:
@@ -944,6 +942,7 @@ class CosmicFengine():
         while True:
             #Check that delay tracking is on
             if not self.delay_switch.is_set():
+
                 break
 
             #Load the delay values from redis

--- a/software/control_sw/src/cosmic_fengine.py
+++ b/software/control_sw/src/cosmic_fengine.py
@@ -920,15 +920,15 @@ class CosmicFengine():
         self.delay_tracking_thread.join()    
         self.delay.initialize()
         self.phaserotate.initialize()
-        self.delay_tracking_thread = threading.Thread(
-            target=self.delay_tracking, args=(), daemon=False
-        )
 
     def start_delay_tracking(self):
         if self.delay_tracking_thread.is_alive():
             self.logger.error(f"Delay tracking thread is running. Ignoring request.")
             return
         self.delay_switch.set()
+        self.delay_tracking_thread = threading.Thread(
+            target=self.delay_tracking, args=(), daemon=False
+        )
         self.delay_tracking_thread.start()
 
     def delay_tracking(self):

--- a/software/control_sw/src/cosmic_fengine.py
+++ b/software/control_sw/src/cosmic_fengine.py
@@ -1,11 +1,10 @@
 import logging
 import numpy as np
-import struct
 import time
-import datetime
 import os
 import redis
 import json
+import ast
 import casperfpga
 import threading
 from . import helpers
@@ -829,6 +828,11 @@ class CosmicFengine():
                     self.fpga.set_connected_antname(ant)
         else:
             self.fpga.set_connected_antname(None)
+        #set the redis channels on which this object listens for delay tracking (name dependant):
+        self.delay_channel_names = [
+            f"{self.fpga.get_connected_antname()}_delays",
+            f"{self.fpga.get_connected_antname()}_calibration_delays"
+        ]
 
     def set_delays(self, delays, delay_rates, phases, phase_rates, clock_rate_hz=2048000000, invert_band=False):
         """
@@ -917,7 +921,19 @@ class CosmicFengine():
             self.logger.error(f"Delay tracking thread is stopped. Ignoring request.")
             return 
         self.delay_switch.clear()
-        self.delay_tracking_thread.join()    
+        self.delay_tracking_thread.join()
+
+        #Unsubscribe to the required redis channels
+        if self.redis_obj is not None:
+            for channel in self.delay_channel_names:
+                try:
+                    self.pubsub.unsubscribe(channel) 
+                except redis.RedisError:
+                    self.logger.warn(f'Unsubscription from `{channel}` unsuccessful.')    
+        else:
+            self.logger.warn("""Cosmic Fengine has no redis object instance. No subscribed channels
+            to unsubscribe from.""")
+            return
         self.delay.initialize()
         self.phaserotate.initialize()
 
@@ -926,6 +942,20 @@ class CosmicFengine():
             self.logger.error(f"Delay tracking thread is running. Ignoring request.")
             return
         self.delay_switch.set()
+
+        #Subscribe to the required redis channels
+        if self.redis_obj is not None:
+            self.pubsub = self.redis_obj.pubsub(ignore_subscribe_messages=True)
+            for channel in self.delay_channel_names:
+                try:
+                    self.pubsub.subscribe(channel) 
+                except redis.RedisError:
+                    self.logger.error(f'Subscription to `{channel}` unsuccessful.')
+        else:
+            self.logger.warn("""Cosmic Fengine has no redis object instance. Cannot load delays
+            for delay tracking.""")
+            return
+
         self.delay_tracking_thread = threading.Thread(
             target=self.delay_tracking, args=(), daemon=False
         )
@@ -934,80 +964,73 @@ class CosmicFengine():
     def delay_tracking(self):
         """
         Started in a thread, this function calls on delay_tracking to update the fengine coefficients for 
-        delay tracking. It reads the delay, delay rate and delay rate rate coefficients from redis
-        and calculate the delay, delay rate, phase and phase rate for the F-Engine
+        delay tracking. It listens for the delay, delay rate and delay rate rate coefficients on {antname}_delays
+        channel along with calibration delay values on {antname}_calibration_delays
+        and calculates the delay, delay rate, phase and phase rate for the F-Engine before calling set_delays()
+        to load them
         """
-        DELAY_POLLING_PERIOD = 5 #s
-        DELAY_LOADING_PERIOD = 1 #s
-        PERIODS_PER_PERIOD = DELAY_POLLING_PERIOD//DELAY_LOADING_PERIOD
-        #Open the outer while loop for the redis polling:
-        while self.delay_switch.is_set():
-
-            #Load the delay values from redis
-            if self.redis_obj is not None:
-
-                #Fetch calibration delays:
-                delay_calib = self.redis_obj.hget("META_calibrationDelays", self.fpga.get_connected_antname())
-                try:
-                    delay_calib = json.loads(delay_calib)
-                except:
-                    pass
-                delay_calib = np.fromiter(delay_calib.values(), dtype=float)
-
-                #If performing full tracking with calibrations:
-                if self.delay_track.is_set():
-                    #Fetch delay model delays
-                    delay_coeffs = self.redis_obj.hget("META_modelDelays", self.fpga.get_connected_antname())
-                    try:
-                        delay_coeffs = json.loads(delay_coeffs)
-                    except:
-                        pass
-        
-                    #Open an inner while loop of a higher cadence than the redis polling one:
-                    iteration = 0 
-                    while iteration < PERIODS_PER_PERIOD:
-                        onesec_future = (time.time() + 1)
-                        onesec_future_spectra_mult = int(onesec_future*1e6)
-                        onesec_future_spectra_mult_fpgaclks =  onesec_future_spectra_mult * 256 #in fpga clocks
-
-                        loadtime_diff_modeltime = (onesec_future_spectra_mult/(1e6) - delay_coeffs["time_value"]) #calculate 1s into the future
-                        delay_raterate = delay_coeffs["delay_raterate_nsps2"]
-                        delay_rate = delay_coeffs["delay_rate_nsps"]
-                        delay = delay_coeffs["delay_ns"]
-                        # T = ax^2 + bx + c
-                        delay_at_loadtime_diff_modeltime = [delay_raterate*(loadtime_diff_modeltime**2) + delay_rate*loadtime_diff_modeltime + delay]*self.delay.n_streams
-                        # dT/dt = 2ax + b
-                        delay_rate_at_loadtime_diff_modeltime = [delay_raterate*2*loadtime_diff_modeltime + delay_rate]*self.delay.n_streams
-                        
-                        #Add calibrations:
-                        delay_at_loadtime_diff_modeltime_calib = np.array(delay_at_loadtime_diff_modeltime) + delay_calib
-
-                        #Load delays:
-                        self.set_delays(delay_at_loadtime_diff_modeltime_calib, delay_rate_at_loadtime_diff_modeltime,
-                                            [0,0,0,0], [0,0,0,0])
-
-                        self.delay.set_target_load_time(onesec_future_spectra_mult_fpgaclks)
-                        self.phaserotate.set_target_load_time(onesec_future_spectra_mult_fpgaclks)
-
-                        iteration += 1
-                
-                #If just doing calibration mode:
-                else:
-                    #Load calibration delays:
-                    self.set_delays(delay_calib, [0,0,0,0], [0,0,0,0], [0,0,0,0])
-                    #Force load delays:
-                    self.delay.force_load()
-                    self.phaserotate.force_load()
-
-                time.sleep(DELAY_LOADING_PERIOD) 
-
-            else:
-                self.logger.warn("""Cosmic Fengine has no redis object instance. Cannot load delays
-                for delay tracking.""")
+        #Open the outer while loop for the redis channel listener:
+        delays_initialised = False
+        calibration_delays_initialised = False
+        while True:
+            if not self.delay_switch.is_set():
                 break
-                
-            time.sleep(DELAY_POLLING_PERIOD)
-        self.logger.warn(f"While loop exited, expectedly {not self.delay_switch.is_set()}")
+            message = self.pubsub.get_message(timeout=0.1)
+
+            try:
+                if message:
+                    if "message" == message["type"]:
+                        #New delay values received
+                        message_data = ast.literal_eval(message.get('data'))
+                        if self.delay_channel_names[0] == message['channel']:
+                            #This is a delay value
+                            delay_coeffs = message_data
+                            if not delays_initialised:
+                                delays_initialised = True
+                        if self.delay_channel_names[1] == message['channel']:
+                            #This is a calibration delay value
+                            delay_calib = np.fromiter(message_data.values(),dtype=float)
+                            if not calibration_delays_initialised:
+                                calibration_delays_initialised = True
+
+                else:
+                    #No values received, load values on hand
+                    if self.delay_track.is_set():
+                        if delays_initialised and calibration_delays_initialised:
+                            onesec_future = (time.time() + 1)
+                            onesec_future_spectra_mult = int(onesec_future*1e6)
+                            onesec_future_spectra_mult_fpgaclks =  onesec_future_spectra_mult * 256 #in fpga clocks
+
+                            loadtime_diff_modeltime = (onesec_future_spectra_mult/(1e6) - delay_coeffs["time_value"]) #calculate 1s into the future
+                            delay_raterate = delay_coeffs["delay_raterate_nsps2"]
+                            delay_rate = delay_coeffs["delay_rate_nsps"]
+                            delay = delay_coeffs["delay_ns"]
+                            # T = ax^2 + bx + c
+                            delay_at_loadtime_diff_modeltime = [delay_raterate*(loadtime_diff_modeltime**2) + delay_rate*loadtime_diff_modeltime + delay]*self.delay.n_streams
+                            # dT/dt = 2ax + b
+                            delay_rate_at_loadtime_diff_modeltime = [delay_raterate*2*loadtime_diff_modeltime + delay_rate]*self.delay.n_streams
+                            
+                            #Add calibrations:
+                            delay_at_loadtime_diff_modeltime_calib = np.array(delay_at_loadtime_diff_modeltime) + delay_calib
+
+                            #Load delays:
+                            self.set_delays(delay_at_loadtime_diff_modeltime_calib, delay_rate_at_loadtime_diff_modeltime,
+                                                [0,0,0,0], [0,0,0,0])
+
+                            self.delay.set_target_load_time(onesec_future_spectra_mult_fpgaclks)
+                            self.phaserotate.set_target_load_time(onesec_future_spectra_mult_fpgaclks)
+
+                    else:
+                        if calibration_delays_initialised:
+                            #Load calibration delays:
+                            self.set_delays(delay_calib, [0,0,0,0], [0,0,0,0], [0,0,0,0])
+                            #Force load delays:
+                            self.delay.force_load()
+                            self.phaserotate.force_load()
+
+            except BaseException as err:
+                print(repr(err))
+                break
 
     #FOR TESTING ONLY
     def set_delay_tracking(self, delays, delay_rates, phases, phase_rates, load_time=None, clock_rate_hz=2048000000, invert_band=False):

--- a/software/control_sw/src/cosmic_fengine.py
+++ b/software/control_sw/src/cosmic_fengine.py
@@ -834,6 +834,159 @@ class CosmicFengine():
             Internally, delay rate is converted from nanoseconds-per-second to
             samples-per-spectra. Firmware delays are updated every 4 spectra.
         :type delay_rates: float
+        :param delay_rate_rates: 4-tuple of delay rate rates for X and Y polarizations for both tunings. Each value is
+            the delay rate rate, in nanoseconds per second^2. The incremental delay
+            which should be added to the current delay each second.
+            Internally, delay rate rate is converted from nanoseconds-per-second^2 to
+            samples-per-spectra. Firmware delays are updated every 4 spectra.
+        :type delay_rate_rates: float
+        :param clock_rate_hz: ADC clock rate in Hz. If None, the clock rate will be computed from
+            the observed PPS interval, which could fail if the PPS is unstable or not present.
+        :type clock_rate_hz: int
+        :param invert_band: If True, invert the gradient of the phase-vs-frequency channel. I.e.,
+            apply a fractional delay which is the negative of the physical delay.
+        :type invert_band: bool
+        """
+        delay_samples = np.array(delays) * (1e-9 * clock_rate_hz)
+        delay_samples_int = np.zeros(self.delay.n_streams, dtype=int)
+        for if_id in range(self.delay.n_streams):
+            # If delay rate is positive, want to make fractional delay as small as possible,
+            # so round delay up
+            if delay_rates[if_id] > 0:
+                delay_samples_int[if_id] = int(np.ceil(delay_samples[if_id]))
+            # If delay rate is negative, we want to make fractional delay as large as possible,
+            # so round integer delay down
+            elif delay_rates[if_id]==0:
+                if delay_samples[if_id] >=0:
+                    delay_samples_int[if_id] = int(np.floor(delay_samples[if_id]))
+                else:
+                    delay_samples_int[if_id] = int(np.ceil(delay_samples[if_id]))
+            else:
+                delay_samples_int[if_id] = int(np.floor(delay_samples[if_id]))
+
+        delay_samples_frac = (delay_samples - delay_samples_int).astype(np.float)
+        # Massage rates into samples-per-spectra (lots of redundant use of clock rate...)
+        delay_rates_samples_per_sec = np.array(delay_rates) * 1e-9 * clock_rate_hz
+        delay_rates_samples_per_spec = delay_rates_samples_per_sec * (2* self.autocorr.n_chans) / clock_rate_hz
+        # Convert phases to range +/- pi and normalize
+        phases = np.array(phases) / np.pi # normalize to fractions of pi
+        phases = ((phases + 1) % 2) - 1   # place in range +/- 1
+
+        # Convert phase rates to fractions of pi per spectra
+        self.logger.debug("Phase rates [radians per sec]: %s" % phase_rates)
+        phase_rates_per_spec = np.array(phase_rates) * (2*self.autocorr.n_chans) / clock_rate_hz
+        self.logger.debug("Phase rates [radians per spectrum]: %s" % phase_rates_per_spec)
+        phase_rates_per_spec = phase_rates_per_spec / np.pi # normalize to fractions of pi
+        self.logger.debug("Phase rates [pis per spectrum]: %s" % phase_rates_per_spec)
+        phase_rates_per_spec = ((phase_rates_per_spec + 1) % 2) - 1        # place in range +/- 1
+        self.logger.debug("Wrapped Phase rates [pis per spectrum]: %s" % phase_rates_per_spec)
+        self.logger.debug("Integer sample delays: %s" % (delay_samples_int))
+        self.logger.debug("Fractional sample delays: %s" % (delay_samples_frac))
+        self.logger.debug("Phase being set to: %s" % phases)
+        self.logger.debug("Phase rates being set to: %s" % phase_rates_per_spec)
+
+        #Load the delays:
+        self.delay.disable_load() # Disable load during configuration for delay
+        self.phaserotate.disable_load() # Disable load during configuration for phaserotate
+        
+        for i in range(self.delay.n_streams):
+            self.delay.set_delay(i, delay_samples_int[i])
+            delay_frac = delay_samples_frac[i]
+            delay_rate = delay_rates_samples_per_spec[i]
+            if invert_band:
+                delay_frac = -delay_frac
+                delay_rate = -delay_rate
+
+            self.phaserotate.set_delay(i, delay_frac)
+            self.phaserotate.set_delay_rate(i, delay_rate)
+            self.phaserotate.set_phase(i, phases[i])
+            self.phaserotate.set_phase_rate(i, phase_rates_per_spec[i])
+
+    def start_delay_tracking(self, clock_rate_hz=2048000000, invert_band=False):
+        """
+        Started in a thread, this function calls on delay_tracking to update the fengine coefficients for 
+        delay tracking. It reads the delay, delay rate and delay rate rate coefficients from redis
+        and calculate the delay, delay rate, phase and phase rate for the F-Engine
+
+        :param redis_host: The host ip for the redis server
+        :type redis_host: str
+        :param redis_port: The redis server port
+        :type redis_port: int
+        :param clock_rate_hz: The FPGA clock rate
+        :type clock_rate_hz: int
+        :param invert_band: If True, invert the gradient of the phase-vs-frequency channel. I.e.,
+            apply a fractional delay which is the negative of the physical delay.
+        :type invert_band: bool
+        """
+        DELAY_POLLING_PERIOD = 5 #s
+        DELAY_LOADING_PERIOD = 1 #s
+        PERIODS_PER_PERIOD = DELAY_POLLING_PERIOD//DELAY_LOADING_PERIOD
+        #Open the outer while loop for the redis polling:
+        for i in range(10):
+            print(f"Outside loop entered. Iteration {i}")
+            #Load the delay values from redis
+            if self.redis_obj is not None:
+                delay_coeffs = self.redis_obj.hget("META_modelDelays", self.fpga.get_connected_antname())
+                try:
+                    delay_coeffs = json.loads(delay_coeffs)
+                except:
+                    pass
+                    
+                print(f"Fetched the following delay coefficients:\n{delay_coeffs}")
+            else:
+                logging.warn("""Cosmic Fengine has no redis object instance. Cannot load delays
+                for delay tracking.""")
+                return
+        
+            #Open an inner while loop of a higher cadence than the redis polling one:
+            iteration = 0 
+            while iteration < PERIODS_PER_PERIOD:
+                print("Inside loop entered")
+                onesec_future = (time.time() + 1)
+                onesec_future_spectra_mult = int(onesec_future*1e6)
+                onesec_future_spectra_mult_fpgaclks =  onesec_future_spectra_mult * 256 #in fpga clocks
+
+                loadtime_diff_modeltime = (onesec_future_spectra_mult/(1e6) - delay_coeffs["time_value"]) #calculate 1s into the future
+                delay_raterate = delay_coeffs["delay_raterate_nsps2"]
+                delay_rate = delay_coeffs["delay_rate_nsps"]
+                delay = delay_coeffs["delay_ns"]
+                # T = ax^2 + bx + c
+                delay_at_loadtime_diff_modeltime = [delay_raterate*(loadtime_diff_modeltime**2) + delay_rate*loadtime_diff_modeltime + delay]*self.delay.n_streams
+                # dT/dt = 2ax + b
+                delay_rate_at_loadtime_diff_modeltime = [delay_raterate*2*loadtime_diff_modeltime + delay_rate]*self.delay.n_streams
+                
+                print(f"Delay calculated for time {loadtime_diff_modeltime}")
+                print(f"Delay value being loaded:\n{delay_at_loadtime_diff_modeltime} delay")
+                print(f"Delay rate value being loaded:\n{delay_rate_at_loadtime_diff_modeltime} delay/ns")
+
+                #Load delays:
+                self.delay_tracking(delay_at_loadtime_diff_modeltime, delay_rate_at_loadtime_diff_modeltime,
+                                     [0,0,0,0], [0,0,0,0],
+                                     clock_rate_hz=clock_rate_hz, invert_band=invert_band)
+
+                print(f"Delay load times being set to: {onesec_future_spectra_mult_fpgaclks}")
+                self.delay.set_target_load_time(onesec_future_spectra_mult_fpgaclks)
+                self.phaserotate.set_target_load_time(onesec_future_spectra_mult_fpgaclks)
+
+                iteration +=1
+                time.sleep(DELAY_LOADING_PERIOD)
+                
+            time.sleep(DELAY_POLLING_PERIOD)
+
+    def set_delay_tracking(self, delays, delay_rates, phases, phase_rates, load_time=None, clock_rate_hz=2048000000, invert_band=False):
+        """
+        Set the delay tracking for this F-Engine once.
+        :param delays: 4-tuple of delays for X and Y polarizations for both tunings. Each value is 
+            the delay, in nanoseconds, which should be applied at the appropriate time.
+            Whole ADC sample delays are implemented using a coarse delay, while sub-sample
+            delays are implemented as a post-FFT phase rotation.
+        :type delays: float
+        :param delay_rates: 4-tuple of delay rates for X and Y polarizations for both tunings. Each value is
+            the delay rate, in nanoseconds per second. The incremental delay
+            which should be added to the current delay each second.
+            Internally, delay rate is converted from nanoseconds-per-second to
+            samples-per-spectra. Firmware delays are updated every 4 spectra.
+        :type delay_rates: float
         :param phases: 4-tuple of phases for X and Y polarizations for both tunings. Each value is the phase, in radians,
             which should be applied at the appropriate time.
         :type phases: float
@@ -859,60 +1012,10 @@ class CosmicFengine():
         else:
             load_time=int(load_time)
 
-        delay_samples = np.array(delays) * (1e-9 * clock_rate_hz)
-        delay_samples_int = np.zeros(self.delay.n_streams, dtype=int)
-        for if_id in range(self.delay.n_streams):
-            # If delay rate is positive, want to make fractional delay as small as possible,
-            # so round delay up
-            if delay_rates[if_id] > 0:
-                delay_samples_int[if_id] = int(np.ceil(delay_samples[if_id]))
-            # If delay rate is negative, we want to make fractional delay as large as possible,
-            # so round integer delay down
-            elif delay_rates[if_id]==0:
-                if delay_samples[if_id] >=0:
-                    delay_samples_int[if_id] = int(np.floor(delay_samples[if_id]))
-                else:
-                    delay_samples_int[if_id] = int(np.ceil(delay_samples[if_id]))
-            else:
-                delay_samples_int[if_id] = int(np.floor(delay_samples[if_id]))
-
-        delay_samples_frac = (delay_samples - delay_samples_int).astype(np.float)
-        # Massage rates into samples-per-spectra (lots of redundant use of clock rate...)
-        delay_rates_samples_per_sec = np.array(delay_rates) * 1e-9 * clock_rate_hz
-        delay_rates_samples_per_spec = delay_rates_samples_per_sec * (2* self.autocorr.n_chans) / clock_rate_hz
-        # Convert phases to range +/- pi and normalize
-        phases = np.array(phases) / np.pi # normalize to fractions of pi
-        phases = ((phases + 1) % 2) - 1   # place in range +/- 1
-        # Convert phase rates to fractions of pi per spectra
-        self.logger.debug("Phase rates [radians per sec]: %s" % phase_rates)
-        phase_rates_per_spec = np.array(phase_rates) * (2*self.autocorr.n_chans) / clock_rate_hz
-        self.logger.debug("Phase rates [radians per spectrum]: %s" % phase_rates_per_spec)
-        phase_rates_per_spec = phase_rates_per_spec / np.pi # normalize to fractions of pi
-        self.logger.debug("Phase rates [pis per spectrum]: %s" % phase_rates_per_spec)
-        phase_rates_per_spec = ((phase_rates_per_spec + 1) % 2) - 1        # place in range +/- 1
-        self.logger.debug("Wrapped Phase rates [pis per spectrum]: %s" % phase_rates_per_spec)
-        self.logger.debug("Setting delays to %s ns at time %s" % (delays, time.ctime(load_time)))
-        self.logger.debug("Integer sample delays: %s" % (delay_samples_int))
-        self.logger.debug("Fractional sample delays: %s" % (delay_samples_frac))
-        self.logger.debug("Phase being set to: %s" % phases)
-        self.logger.debug("Phase rates being set to: %s" % phase_rates_per_spec)
-
-        #Load the delays:
-        self.delay.disable_load() # Disable load during configuration for delay
-        self.phaserotate.disable_load() # Disable load during configuration for phaserotate
-        
-        for i in range(self.delay.n_streams):
-            self.delay.set_delay(i, delay_samples_int[i])
-            delay_frac = delay_samples_frac[i]
-            delay_rate = delay_rates_samples_per_spec[i]
-            if invert_band:
-                delay_frac = -delay_frac
-                delay_rate = -delay_rate
-
-            self.phaserotate.set_delay(i, delay_frac)
-            self.phaserotate.set_delay_rate(i, delay_rate)
-            self.phaserotate.set_phase(i, phases[i])
-            self.phaserotate.set_phase_rate(i, phase_rates_per_spec[i])
+        self.logger.debug("Setting delays at time %s" % (time.ctime(load_time)))
+        self.delay_tracking(delays, delay_rates, phases, phase_rates,clock_rate_hz,invert_band)
+       
+        #Handle the loading time/force loading of the delays
         if force_delay_load:
             self.delay.force_load()
             self.phaserotate.force_load()

--- a/software/control_sw/src/cosmic_fengine.py
+++ b/software/control_sw/src/cosmic_fengine.py
@@ -57,16 +57,6 @@ class CosmicFengine():
         device with enumeration 0xB
     :type host: casperfpga.CasperFpga
 
-    :param remote_uri: REST host address, eg. `http://192.168.32.100:5000`. This 
-        triggers the transport to be a RemotePcieTransport object.
-    :type remote_uri: str
-
-    :param redis_host: Redis server host address
-    :type redis_host: str
-
-    :param redis_port: Redis server port address
-    :type redis_port: str
-
     :param fpgfile: .fpg file for firmware to program (or already loaded)
     :type fpgfile: str
 
@@ -79,9 +69,18 @@ class CosmicFengine():
     :param logger: Logger instance to which log messages should be emitted.
     :type logger: logging.Logger
 
+    :param remote_uri: REST host address, eg. `http://192.168.32.100:5000`. This 
+    triggers the transport to be a RemotePcieTransport object.
+    :type remote_uri: str
+
+    :param redis_host: Redis server host address
+    :type redis_host: str
+
+    :param redis_port: Redis server port address
+    :type redis_port: int
     """
 
-    def __init__(self, host, fpgfile, pipeline_id=0, neths=1, logger=None, remote_uri=None, redis_host=None, redis_port=None):
+    def __init__(self, host, fpgfile, pipeline_id=0, neths=1, logger=None, remote_uri=None, redis_host=None, redis_port=6379):
         self.hostname = host #: hostname of the F-Engine's host SNAP2 board
         self.pipeline_id = pipeline_id
         self.fpgfile = fpgfile
@@ -111,7 +110,7 @@ class CosmicFengine():
             else:
                 self._cfpga.upload_to_ram_and_program(fpgfile)
             
-        if redis_host is None or redis_port is None:
+        if redis_host is None:
             self.redis_obj = None
         else:
             self.redis_obj = redis.Redis(host = redis_host, port = redis_port, decode_responses=True)

--- a/software/control_sw/src/cosmic_fengine.py
+++ b/software/control_sw/src/cosmic_fengine.py
@@ -1,10 +1,11 @@
 import logging
 import numpy as np
+import struct
 import time
+import datetime
 import os
 import redis
 import json
-import ast
 import casperfpga
 import threading
 from . import helpers
@@ -774,6 +775,7 @@ class CosmicFengine():
                         except IndexError:
                             self.logger.debug('skipping channel start %d for input %d because it isnt in the feng_ids list' % (chan, ant))
                             continue
+                        chan_indices[pkt_num] += start_chan
                         ips[pkt_num] = dest_ip
                         ports[pkt_num] = dest_port
                         # Use the order maps to figure out where we should put these antchans
@@ -828,11 +830,6 @@ class CosmicFengine():
                     self.fpga.set_connected_antname(ant)
         else:
             self.fpga.set_connected_antname(None)
-        #set the redis channels on which this object listens for delay tracking (name dependant):
-        self.delay_channel_names = [
-            f"{self.fpga.get_connected_antname()}_delays",
-            f"{self.fpga.get_connected_antname()}_calibration_delays"
-        ]
 
     def set_delays(self, delays, delay_rates, phases, phase_rates, clock_rate_hz=2048000000, invert_band=False):
         """
@@ -921,19 +918,7 @@ class CosmicFengine():
             self.logger.error(f"Delay tracking thread is stopped. Ignoring request.")
             return 
         self.delay_switch.clear()
-        self.delay_tracking_thread.join()
-
-        #Unsubscribe to the required redis channels
-        if self.redis_obj is not None:
-            for channel in self.delay_channel_names:
-                try:
-                    self.pubsub.unsubscribe(channel) 
-                except redis.RedisError:
-                    self.logger.warn(f'Unsubscription from `{channel}` unsuccessful.')    
-        else:
-            self.logger.warn("""Cosmic Fengine has no redis object instance. No subscribed channels
-            to unsubscribe from.""")
-            return
+        self.delay_tracking_thread.join()    
         self.delay.initialize()
         self.phaserotate.initialize()
 
@@ -942,20 +927,6 @@ class CosmicFengine():
             self.logger.error(f"Delay tracking thread is running. Ignoring request.")
             return
         self.delay_switch.set()
-
-        #Subscribe to the required redis channels
-        if self.redis_obj is not None:
-            self.pubsub = self.redis_obj.pubsub(ignore_subscribe_messages=True)
-            for channel in self.delay_channel_names:
-                try:
-                    self.pubsub.subscribe(channel) 
-                except redis.RedisError:
-                    self.logger.error(f'Subscription to `{channel}` unsuccessful.')
-        else:
-            self.logger.warn("""Cosmic Fengine has no redis object instance. Cannot load delays
-            for delay tracking.""")
-            return
-
         self.delay_tracking_thread = threading.Thread(
             target=self.delay_tracking, args=(), daemon=False
         )
@@ -964,73 +935,80 @@ class CosmicFengine():
     def delay_tracking(self):
         """
         Started in a thread, this function calls on delay_tracking to update the fengine coefficients for 
-        delay tracking. It listens for the delay, delay rate and delay rate rate coefficients on {antname}_delays
-        channel along with calibration delay values on {antname}_calibration_delays
-        and calculates the delay, delay rate, phase and phase rate for the F-Engine before calling set_delays()
-        to load them
+        delay tracking. It reads the delay, delay rate and delay rate rate coefficients from redis
+        and calculate the delay, delay rate, phase and phase rate for the F-Engine
         """
-        #Open the outer while loop for the redis channel listener:
-        delays_initialised = False
-        calibration_delays_initialised = False
-        while True:
-            if not self.delay_switch.is_set():
-                break
-            message = self.pubsub.get_message(timeout=0.1)
+        DELAY_POLLING_PERIOD = 5 #s
+        DELAY_LOADING_PERIOD = 1 #s
+        PERIODS_PER_PERIOD = DELAY_POLLING_PERIOD//DELAY_LOADING_PERIOD
+        #Open the outer while loop for the redis polling:
+        while self.delay_switch.is_set():
 
-            try:
-                if message:
-                    if "message" == message["type"]:
-                        #New delay values received
-                        message_data = ast.literal_eval(message.get('data'))
-                        if self.delay_channel_names[0] == message['channel']:
-                            #This is a delay value
-                            delay_coeffs = message_data
-                            if not delays_initialised:
-                                delays_initialised = True
-                        if self.delay_channel_names[1] == message['channel']:
-                            #This is a calibration delay value
-                            delay_calib = np.fromiter(message_data.values(),dtype=float)
-                            if not calibration_delays_initialised:
-                                calibration_delays_initialised = True
+            #Load the delay values from redis
+            if self.redis_obj is not None:
 
+                #Fetch calibration delays:
+                delay_calib = self.redis_obj.hget("META_calibrationDelays", self.fpga.get_connected_antname())
+                try:
+                    delay_calib = json.loads(delay_calib)
+                except:
+                    pass
+                delay_calib = np.fromiter(delay_calib.values(), dtype=float)
+
+                #If performing full tracking with calibrations:
+                if self.delay_track.is_set():
+                    #Fetch delay model delays
+                    delay_coeffs = self.redis_obj.hget("META_modelDelays", self.fpga.get_connected_antname())
+                    try:
+                        delay_coeffs = json.loads(delay_coeffs)
+                    except:
+                        pass
+        
+                    #Open an inner while loop of a higher cadence than the redis polling one:
+                    iteration = 0 
+                    while iteration < PERIODS_PER_PERIOD:
+                        onesec_future = (time.time() + 1)
+                        onesec_future_spectra_mult = int(onesec_future*1e6)
+                        onesec_future_spectra_mult_fpgaclks =  onesec_future_spectra_mult * 256 #in fpga clocks
+
+                        loadtime_diff_modeltime = (onesec_future_spectra_mult/(1e6) - delay_coeffs["time_value"]) #calculate 1s into the future
+                        delay_raterate = delay_coeffs["delay_raterate_nsps2"]
+                        delay_rate = delay_coeffs["delay_rate_nsps"]
+                        delay = delay_coeffs["delay_ns"]
+                        # T = ax^2 + bx + c
+                        delay_at_loadtime_diff_modeltime = [delay_raterate*(loadtime_diff_modeltime**2) + delay_rate*loadtime_diff_modeltime + delay]*self.delay.n_streams
+                        # dT/dt = 2ax + b
+                        delay_rate_at_loadtime_diff_modeltime = [delay_raterate*2*loadtime_diff_modeltime + delay_rate]*self.delay.n_streams
+                        
+                        #Add calibrations:
+                        delay_at_loadtime_diff_modeltime_calib = np.array(delay_at_loadtime_diff_modeltime) + delay_calib
+
+                        #Load delays:
+                        self.set_delays(delay_at_loadtime_diff_modeltime_calib, delay_rate_at_loadtime_diff_modeltime,
+                                            [0,0,0,0], [0,0,0,0])
+
+                        self.delay.set_target_load_time(onesec_future_spectra_mult_fpgaclks)
+                        self.phaserotate.set_target_load_time(onesec_future_spectra_mult_fpgaclks)
+
+                        iteration += 1
+                
+                #If just doing calibration mode:
                 else:
-                    #No values received, load values on hand
-                    if self.delay_track.is_set():
-                        if delays_initialised and calibration_delays_initialised:
-                            onesec_future = (time.time() + 1)
-                            onesec_future_spectra_mult = int(onesec_future*1e6)
-                            onesec_future_spectra_mult_fpgaclks =  onesec_future_spectra_mult * 256 #in fpga clocks
+                    #Load calibration delays:
+                    self.set_delays(delay_calib, [0,0,0,0], [0,0,0,0], [0,0,0,0])
+                    #Force load delays:
+                    self.delay.force_load()
+                    self.phaserotate.force_load()
 
-                            loadtime_diff_modeltime = (onesec_future_spectra_mult/(1e6) - delay_coeffs["time_value"]) #calculate 1s into the future
-                            delay_raterate = delay_coeffs["delay_raterate_nsps2"]
-                            delay_rate = delay_coeffs["delay_rate_nsps"]
-                            delay = delay_coeffs["delay_ns"]
-                            # T = ax^2 + bx + c
-                            delay_at_loadtime_diff_modeltime = [delay_raterate*(loadtime_diff_modeltime**2) + delay_rate*loadtime_diff_modeltime + delay]*self.delay.n_streams
-                            # dT/dt = 2ax + b
-                            delay_rate_at_loadtime_diff_modeltime = [delay_raterate*2*loadtime_diff_modeltime + delay_rate]*self.delay.n_streams
-                            
-                            #Add calibrations:
-                            delay_at_loadtime_diff_modeltime_calib = np.array(delay_at_loadtime_diff_modeltime) + delay_calib
+                time.sleep(DELAY_LOADING_PERIOD) 
 
-                            #Load delays:
-                            self.set_delays(delay_at_loadtime_diff_modeltime_calib, delay_rate_at_loadtime_diff_modeltime,
-                                                [0,0,0,0], [0,0,0,0])
-
-                            self.delay.set_target_load_time(onesec_future_spectra_mult_fpgaclks)
-                            self.phaserotate.set_target_load_time(onesec_future_spectra_mult_fpgaclks)
-
-                    else:
-                        if calibration_delays_initialised:
-                            #Load calibration delays:
-                            self.set_delays(delay_calib, [0,0,0,0], [0,0,0,0], [0,0,0,0])
-                            #Force load delays:
-                            self.delay.force_load()
-                            self.phaserotate.force_load()
-
-            except BaseException as err:
-                print(repr(err))
+            else:
+                self.logger.warn("""Cosmic Fengine has no redis object instance. Cannot load delays
+                for delay tracking.""")
                 break
+                
+            time.sleep(DELAY_POLLING_PERIOD)
+        self.logger.warn(f"While loop exited, expectedly {not self.delay_switch.is_set()}")
 
     #FOR TESTING ONLY
     def set_delay_tracking(self, delays, delay_rates, phases, phase_rates, load_time=None, clock_rate_hz=2048000000, invert_band=False):

--- a/software/control_sw/src/cosmic_fengine.py
+++ b/software/control_sw/src/cosmic_fengine.py
@@ -915,6 +915,7 @@ class CosmicFengine():
     def stop_delay_tracking(self):
         if not self.delay_tracking_thread.is_alive():
             logging.error(f"Delay tracking thread is stopped. Ignoring request.")
+            return 
         self.delay_switch.clear()
         self.delay_tracking_thread.join()    
         self.delay.initialize()
@@ -926,6 +927,7 @@ class CosmicFengine():
     def start_delay_tracking(self):
         if self.delay_tracking_thread.is_alive():
             logging.error(f"Delay tracking thread is running. Ignoring request.")
+            return
         self.delay_switch.set()
         self.delay_tracking_thread.start()
 

--- a/software/control_sw/src/cosmic_fengine.py
+++ b/software/control_sw/src/cosmic_fengine.py
@@ -914,7 +914,7 @@ class CosmicFengine():
     
     def stop_delay_tracking(self):
         if not self.delay_tracking_thread.is_alive():
-            raise RuntimeError("Delay tracking thread was not running")
+            logging.error(f"Delay tracking thread is stopped. Ignoring request.")
         self.delay_switch.clear()
         self.delay_tracking_thread.join()    
         self.delay.initialize()
@@ -925,7 +925,7 @@ class CosmicFengine():
 
     def start_delay_tracking(self):
         if self.delay_tracking_thread.is_alive():
-            raise RuntimeError("Delay tracking thread is already running")
+            logging.error(f"Delay tracking thread is running. Ignoring request.")
         self.delay_switch.set()
         self.delay_tracking_thread.start()
 
@@ -939,11 +939,7 @@ class CosmicFengine():
         DELAY_LOADING_PERIOD = 1 #s
         PERIODS_PER_PERIOD = DELAY_POLLING_PERIOD//DELAY_LOADING_PERIOD
         #Open the outer while loop for the redis polling:
-        while True:
-            #Check that delay tracking is on
-            if not self.delay_switch.is_set():
-
-                break
+        while self.delay_switch.is_set():
 
             #Load the delay values from redis
             if self.redis_obj is not None:
@@ -1009,6 +1005,7 @@ class CosmicFengine():
                 break
                 
             time.sleep(DELAY_POLLING_PERIOD)
+        logging.warn(f"While loop exited, expectedly {not self.delay_switch.is_set()}")
 
     #FOR TESTING ONLY
     def set_delay_tracking(self, delays, delay_rates, phases, phase_rates, load_time=None, clock_rate_hz=2048000000, invert_band=False):

--- a/software/control_sw/src/cosmic_fengine.py
+++ b/software/control_sw/src/cosmic_fengine.py
@@ -914,7 +914,7 @@ class CosmicFengine():
     
     def stop_delay_tracking(self):
         if not self.delay_tracking_thread.is_alive():
-            logging.error(f"Delay tracking thread is stopped. Ignoring request.")
+            self.logger.error(f"Delay tracking thread is stopped. Ignoring request.")
             return 
         self.delay_switch.clear()
         self.delay_tracking_thread.join()    
@@ -926,7 +926,7 @@ class CosmicFengine():
 
     def start_delay_tracking(self):
         if self.delay_tracking_thread.is_alive():
-            logging.error(f"Delay tracking thread is running. Ignoring request.")
+            self.logger.error(f"Delay tracking thread is running. Ignoring request.")
             return
         self.delay_switch.set()
         self.delay_tracking_thread.start()
@@ -1002,12 +1002,12 @@ class CosmicFengine():
                 time.sleep(DELAY_LOADING_PERIOD) 
 
             else:
-                logging.warn("""Cosmic Fengine has no redis object instance. Cannot load delays
+                self.logger.warn("""Cosmic Fengine has no redis object instance. Cannot load delays
                 for delay tracking.""")
                 break
                 
             time.sleep(DELAY_POLLING_PERIOD)
-        logging.warn(f"While loop exited, expectedly {not self.delay_switch.is_set()}")
+        self.logger.warn(f"While loop exited, expectedly {not self.delay_switch.is_set()}")
 
     #FOR TESTING ONLY
     def set_delay_tracking(self, delays, delay_rates, phases, phase_rates, load_time=None, clock_rate_hz=2048000000, invert_band=False):

--- a/software/control_sw/src/cosmic_fengine.py
+++ b/software/control_sw/src/cosmic_fengine.py
@@ -4,6 +4,7 @@ import struct
 import time
 import datetime
 import os
+import redis
 import json
 import casperfpga
 from . import helpers
@@ -61,6 +62,12 @@ class CosmicFengine():
         triggers the transport to be a RemotePcieTransport object.
     :type remote_uri: str
 
+    :param redis_host: Redis server host address
+    :type redis_host: str
+
+    :param redis_port: Redis server port address
+    :type redis_port: str
+
     :param fpgfile: .fpg file for firmware to program (or already loaded)
     :type fpgfile: str
 
@@ -75,7 +82,7 @@ class CosmicFengine():
 
     """
 
-    def __init__(self, host, fpgfile, pipeline_id=0, neths=1, logger=None, remote_uri=None):
+    def __init__(self, host, fpgfile, pipeline_id=0, neths=1, logger=None, remote_uri=None, redis_host=None, redis_port=None):
         self.hostname = host #: hostname of the F-Engine's host SNAP2 board
         self.pipeline_id = pipeline_id
         self.fpgfile = fpgfile
@@ -105,6 +112,10 @@ class CosmicFengine():
             else:
                 self._cfpga.upload_to_ram_and_program(fpgfile)
             
+        if redis_host is None or redis_port is None:
+            self.redis_obj = None
+        else:
+            self.redis_obj = redis.Redis(host = redis_host, port = redis_port, decode_responses=True)
 
         self.blocks = {}
         try:

--- a/software/control_sw/src/cosmic_fengine.py
+++ b/software/control_sw/src/cosmic_fengine.py
@@ -1013,7 +1013,7 @@ class CosmicFengine():
                 else:
                     #No values received, load values on hand
                     onesec_future_integer = int(time.time() + 1) #1 second into the future
-                    onesec_future_spectra_mult_fpgaclks =  int(onesec_future_integer * 256e6) #in fpga clocks per spectra
+                    onesec_future_spectra_mult_fpgaclks =  int(onesec_future_integer * FPGA_CLOCK_RATE_HZ) #in fpga clocks per spectra
                     
                     if self.delay_track.is_set():
                         if delays_initialised and calibration_delays_initialised:
@@ -1097,8 +1097,8 @@ class CosmicFengine():
         else:
             print("Loading delays...")
             assert load_time > time.time(), f"""Cannot set a load time that is in the past"""   
-            self.delay.set_target_load_time(int(load_time*256e6))
-            self.phaserotate.set_target_load_time(int(load_time*256e6))
+            self.delay.set_target_load_time(int(load_time * FPGA_CLOCK_RATE_HZ))
+            self.phaserotate.set_target_load_time(int(load_time * FPGA_CLOCK_RATE_HZ))
             self.logger.debug(f"""Firmware reports that coarse delays will be loaded in: 
                                 {self.delay.get_time_to_load()} FPGA clocks
                                 and fine delays in:

--- a/software/control_sw/src/cosmic_fengine.py
+++ b/software/control_sw/src/cosmic_fengine.py
@@ -998,13 +998,12 @@ class CosmicFengine():
 
                 else:
                     #No values received, load values on hand
-                    onesec_future = (time.time() + 1)
-                    onesec_future_spectra_mult = int(onesec_future*1e6)
-                    onesec_future_spectra_mult_fpgaclks =  onesec_future_spectra_mult * 256 #in fpga clocks
+                    onesec_future_integer = int(time.time() + 1) #1 second into the future
+                    onesec_future_spectra_mult_fpgaclks =  int(onesec_future_integer * 256e6) #in fpga clocks per spectra
                     
                     if self.delay_track.is_set():
                         if delays_initialised and calibration_delays_initialised:
-                            loadtime_diff_modeltime = (onesec_future_spectra_mult/(1e6) - delay_coeffs["time_value"]) #calculate 1s into the future
+                            loadtime_diff_modeltime = (onesec_future_integer - delay_coeffs["time_value"]) #calculate 1s into the future
                             delay_raterate = delay_coeffs["delay_raterate_nsps2"]
                             delay_rate = delay_coeffs["delay_rate_nsps"]
                             delay = delay_coeffs["delay_ns"]
@@ -1025,11 +1024,11 @@ class CosmicFengine():
                             #Load calibration delays:
                             self.set_delays(delay_calib, [0,0,0,0], [0,0,0,0], [0,0,0,0])
 
-                    assert time.time() < onesec_future, "Error, target load time cannot be set for a time in the past!"
+                    assert time.time() < onesec_future_integer, "Error, target load time cannot be set for a time in the past!"
                     #Load one second into the future:
                     self.delay.set_target_load_time(onesec_future_spectra_mult_fpgaclks)
                     self.phaserotate.set_target_load_time(onesec_future_spectra_mult_fpgaclks)
-                    time.sleep(1) #account for the 1s into the future loading
+                    time.sleep(onesec_future_integer - time.time()) #sleep for the difference between load time and now (to allow for loading)
 
             except BaseException as err:
                 print(repr(err))

--- a/software/control_sw/src/cosmic_fengine.py
+++ b/software/control_sw/src/cosmic_fengine.py
@@ -1084,8 +1084,8 @@ class CosmicFengine():
         else:
             print("Loading delays...")
             assert load_time > time.time(), f"""Cannot set a load time that is in the past"""   
-            self.delay.set_target_load_time(load_time)
-            self.phaserotate.set_target_load_time(load_time)
+            self.delay.set_target_load_time(int(load_time*256e6))
+            self.phaserotate.set_target_load_time(int(load_time*256e6))
             self.logger.debug(f"""Firmware reports that coarse delays will be loaded in: 
                                 {self.delay.get_time_to_load()} FPGA clocks
                                 and fine delays in:


### PR DESCRIPTION
F-Engine object initialises to a state where the delay tracking threads are instantiated but not started.

Once started with `start_delay_tracking()` the delay tracking thread is in a state of "calibration" where it will load only calibration delays.

Setting the delay track event (`.delay_track.set()`) will that change the delay tracking behaviour to apply geometric delays in conjunction with calibration delays.

This delay tracking thread will also listen for new delays published on `{antname}_delays` and `{antname}_calibration_delays` channels for updates to the calibration and geometric delays. When no messages are received, the delay tracking thread will interpolate geometric delays off of the _last received geometric coefficients_ and apply those at a certain cadence.

When the thread is stopped with `stop_delay_tracking()`, the thread is closed, the `delay_track.clear()`, and the `phaserotate` and `delay` blocks are initialised (cleared). The F-Engine object also unsubscribes from the redis channels (no longer listening for delay updates).

