### PR TITLE
Dual 100g

### DIFF
--- a/software/control_sw/config/vla_f_config_jack.yaml
+++ b/software/control_sw/config/vla_f_config_jack.yaml
@@ -1,20 +1,57 @@
 fengines:
-    chans_per_packet: 32
-    pcie0:
+    chans_per_packet: 64
+    dts_lane_map:
+        - [0,1,3,2,4,5,7,6,8,9,11,10] # Default for pipeline ID 0
+        - [4,5,7,6,0,1,3,2,8,9,11,10] # Default for pipeline ID 1
+    pcie65:
         0:
-            inputs: [0, 2]
-            gbes: ['100.100.102.20']
+            feng_ids: [0, 1]
+            gbes: ['192.168.64.20', '192.168.65.20']
             source_port: 10000
         1:
-            inputs: [2, 4]
-            gbes: ['100.100.102.21']
+            feng_ids: [2, 3]
+            gbes: ['192.168.64.21', '192.168.65.21']
             source_port: 10000
+            #dts_lane_map: [8,9,2,3,10,11,4,5,0,1,6,7] Override default if necessary
 
 xengines:
   arp:
     # cosmic-gpu-0
-    100.100.102.100: 0xb8cef6a64188
-    100.100.103.100: 0xb8cef6a64189
+    192.168.64.100: 0xb8cef6a642a1
+    192.168.65.100: 0xb8cef6a64189
+    192.168.64.0  : 0xdeaddeaddead
+    192.168.65.0  : 0xdeaddeaddead
   chans:
+    # Channel destinations are specified as:
+    # ip-port: [[feng_ids], [first_chan, last_chan+1]]
     # cosmic-gpu-0
-    100.100.102.100-10000: [0, 512]
+    192.168.64.100-11111:
+            # The feng_mask/feng_range_mask entries filter the feng_ids
+            # of the pipelines. The feng_ids that will actually be sent
+            # to the xengine-destination is the union of the mask and the
+            # pipeline's feng_ids list.
+
+            # Send specific Feng IDs. This key overrides feng_range
+            # feng_mask: [0,1,2,3,4,5,6,7]
+            # Send a range of fengs. If [x,y] is given, send range(x,y).
+            # If [x,y,z] is given, send range(x,y,z)
+            feng_range_mask: [0,8,2] # Even Feng-IDs
+            # Give [x,y] to send channel range range(x,y)
+            chan_range: [64,128]
+            ethport: 0
+    192.168.64.0-11111:
+            feng_range_mask: [0,8,2] # Odd Feng-IDs
+            # Give [x,y] to send channel range range(x,y)
+            chan_range: [128,192]
+            ethport: 0
+    # cosmic-gpu-0
+    192.168.65.100-11111:
+            feng_range_mask: [1,8,2] # Odd Feng-IDs
+            # Give [x,y] to send channel range range(x,y)
+            chan_range: [64,128]
+            ethport: 0
+    192.168.65.0-11111:
+            feng_range_mask: [1,8,2] # Odd Feng-IDs
+            # Give [x,y] to send channel range range(x,y)
+            chan_range: [128,192]
+            ethport: 0

--- a/software/control_sw/scripts/cosmic_feng_init.py
+++ b/software/control_sw/scripts/cosmic_feng_init.py
@@ -31,6 +31,8 @@ def main():
                         help='Path to .fpg firmware file')
     parser.add_argument('-R','--remote', type=str, default=None,
                         help='URI to remote REST server')
+    parser.add_argument('--neth', type=int, default=1,
+                        help='Number of Ethernet outputs possessed by this pipeline')
     parser.add_argument('fpga_id', type=str, default=0,
                         help='FPGA pcie card ID')
     parser.add_argument('pipeline_id', type=int, default=0,
@@ -39,7 +41,7 @@ def main():
 
 
     f = cosmic_fengine.CosmicFengine(
-        args.fpga_id, args.fpgfile, pipeline_id=args.pipeline_id,
+        args.fpga_id, args.fpgfile, pipeline_id=args.pipeline_id, neths=args.neth,
         remote_uri=args.remote
     )
 

--- a/software/control_sw/src/blocks/packetizer.py
+++ b/software/control_sw/src/blocks/packetizer.py
@@ -298,7 +298,7 @@ class Packetizer(Block):
         return starts, payloads, indices, antchans
         
     def write_config(self, packet_starts, packet_payloads, channel_indices,
-            antenna_ids, dest_ips, dest_ports, nchans_per_packet):
+            antenna_ids, dest_ips, dest_ports, nchans_per_packet, enable=None):
         """
         Write the packetizer configuration BRAMs with appropriate entries.
 
@@ -308,7 +308,7 @@ class Packetizer(Block):
         :type packet_starts: list of int
 
         :param packet_payloads:
-            Word-indices which are data payloads, and should be mared as
+            Word-indices which are data payloads, and should be marked as
             valid (see `get_packet_info()`)
         :type packet_payloads: list of range()s
 
@@ -332,6 +332,10 @@ class Packetizer(Block):
         :param nchans_per_packet: Number of frequency channels per packet sent.
         :type nchans_per_packet: list of int
 
+        :param enable: List of booleans to enable each packet. If None, all
+            packets are assumed valid.
+        :type enable: list of bool
+
         All parameters should have identical lengths.
         """
         n_packets = len(packet_starts)
@@ -341,12 +345,18 @@ class Packetizer(Block):
                 self._error("%s list length %d for %d packets" % (name, len(x), expected_len))
                 raise RuntimeError
 
+        if enable is None:
+            enable = [True] * n_packets
+
         check_length(packet_payloads, n_packets, 'packet_payloads')
         check_length(channel_indices, n_packets, 'channel_indices')
         check_length(antenna_ids, n_packets, 'antenna IDs')
         check_length(dest_ips, n_packets, 'dest ips')
         check_length(dest_ports, n_packets, 'dest_ports')
         check_length(nchans_per_packet, n_packets, 'chans_per_packet')
+
+        print(channel_indices)
+        print(antenna_ids)
 
         # generate template headers for all invalid data
         headers = []
@@ -366,14 +376,14 @@ class Packetizer(Block):
 
         for p in range(n_packets):
             b = packet_starts[p]
-            headers[b]['first'] = True
+            headers[b]['first'] = (enable[p] and dest_ips[p] != '0.0.0.0')
             for j in packet_payloads[p]:
-                headers[j]['valid'] = dest_ips[p] != '0.0.0.0'
+                headers[j]['valid'] = (enable[p] and dest_ips[p] != '0.0.0.0')
                 headers[j]['n_chans'] = nchans_per_packet[p]
                 headers[j]['chan'] = channel_indices[p]
                 headers[j]['feng_id'] = antenna_ids[p]
                 headers[j]['dest_ip'] = dest_ips[p]
                 headers[j]['dest_port'] = dest_ports[p]
-            headers[packet_payloads[p][-1]]['last'] = True
+            headers[packet_payloads[p][-1]]['last'] = (enable[p] and dest_ips[p] != '0.0.0.0')
 
         self._populate_headers(headers)

--- a/software/control_sw/src/blocks/packetizer.py
+++ b/software/control_sw/src/blocks/packetizer.py
@@ -355,9 +355,6 @@ class Packetizer(Block):
         check_length(dest_ports, n_packets, 'dest_ports')
         check_length(nchans_per_packet, n_packets, 'chans_per_packet')
 
-        print(channel_indices)
-        print(antenna_ids)
-
         # generate template headers for all invalid data
         headers = []
         for i in range(self.n_slots):


### PR DESCRIPTION
Support multiple 100G outputs

- Add argument to the `CosmicFengine` constructor defining how many ports a design supports
- Add `ethport` entry to config file which defines which port should be used to emit a chunk of data. If omitted, default is 0. I.e. behaviour from single-port design is maintained.
- Since there are now multiple packetizers, `CosmicFengine.packetizer` becomes the list of instances `CosmicFengine.packetizers`. Since the remote interface doesn't like lists like this, `CosmicFengine.packetizer0` and `CosmicFengine.packetizer1` are created for a 2 port design (similarly to the ethernet interfaces.)
- Add an optional `neth` flag to the initialization script which is passed to the constructor.
- Add "which port" arg to `read_chan_dest_ips_as_json`
- Two Ethernet ports are avaiiable from compile `adm_pcie_9h7_dts_dual_4x100g_dsp_8b_2022-11-08_1132.fpg` (v13.7) onwards