### PR TITLE
DTS Timing Monitoring

### DIFF
--- a/software/control_sw/scripts/testing/check_tt.py
+++ b/software/control_sw/scripts/testing/check_tt.py
@@ -1,0 +1,26 @@
+import time
+from cosmic_f import CosmicFengine
+
+FPGFILE = "/home/jackh/src/vla-dev/firmware/adm_pcie_9h7_dts_dual_4x100g_dsp_8b/outputs/adm_pcie_9h7_dts_dual_4x100g_dsp_8b_2022-11-28_1402.fpg"
+HOSTCARD = 'pcie43'
+
+fpga = CosmicFengine(HOSTCARD, FPGFILE, 0)
+poll_period = 0.05
+
+disabled = False
+while(True):
+    ok = fpga.sync.check_timekeeping()
+    if not ok:
+        fpga.logger.error("Timekeeping error! Disabling Ethernet")
+        disabled = True
+        for eth in fpga.eths:
+            eth.disable_tx()
+    if ok and disabled:
+        fpga.logger.warning("Timekeeping recovery! Enabling Ethernet")
+        disabled = False
+        for eth in fpga.eths:
+            eth.enable_tx()
+    time.sleep(poll_period)
+
+
+

--- a/software/control_sw/scripts/testing/watch_redis.py
+++ b/software/control_sw/scripts/testing/watch_redis.py
@@ -1,0 +1,14 @@
+import time
+import redis
+REDISHOST = "192.168.32.1"
+CHAN = "FENG_dtsMonitor"
+
+r = redis.Redis('192.168.32.1')
+sub = r.pubsub()
+sub.subscribe(CHAN)
+
+for message in sub.listen():
+    if r.get(CHAN+"_alive") is None:
+        print("Channel not active")
+    if message is not None:
+        print(message)

--- a/software/control_sw/src/blocks/sync.py
+++ b/software/control_sw/src/blocks/sync.py
@@ -30,6 +30,8 @@ class Sync(Block):
     OFFSET_MAN_SYNC = 8
     OFFSET_ARM_NOISE = 9
     OFFSET_TT_LOAD_ARM = 10
+    OFFSET_LOOPBACK_EN = 11
+    OFFSET_ERR_DETECT_ENABLE = 12
 
     def __init__(self, host, name, clk_hz=None, logger=None):
         super(Sync, self).__init__(host, name, logger)
@@ -162,6 +164,20 @@ class Sync(Block):
         self.change_reg_bits('ctrl', 1, self.OFFSET_MAN_SYNC)
         self.change_reg_bits('ctrl', 0, self.OFFSET_MAN_SYNC)
         time.sleep(0.2) # Ensure the sync has propagated
+
+    def enable_error_detect(self):
+        """
+        Enable error output, which goes high whenever missing syncs or
+        syncs with inconsistent period are detected.
+        """
+        self.change_reg_bits('ctrl', 1, self.OFFSET_ERR_DETECT_ENABLE)
+
+    def disable_error_detect(self):
+        """
+        Disable error output, which goes high whenever missing syncs or
+        syncs with inconsistent period are detected.
+        """
+        self.change_reg_bits('ctrl', 0, self.OFFSET_ERR_DETECT_ENABLE)
 
     def check_timekeeping(self, sync_rate_hz=20):
         """

--- a/software/control_sw/src/cosmic_fengine.py
+++ b/software/control_sw/src/cosmic_fengine.py
@@ -1068,7 +1068,8 @@ class CosmicFengine():
         """
         disabled = False
         rc = "FENG_dtsMonitor"
-        self.logger.info(f"DTS monitor starting. Alerting to {rc}")
+        self.logger.info(f"DTS monitor for antenna {self.fpga.antname} starting. Alerting to {rc}")
+        test = False
         while(True):
             if self.redis_obj is not None:
                 # Record the fact the thread is alive with an expiring key
@@ -1077,14 +1078,14 @@ class CosmicFengine():
                 self.logger.info("DTS monitor switch is cleared, breaking out of main loop.")
                 break
             ok = self.sync.check_timekeeping()
-            if not ok and not disabled:
+            if test or (not ok and not disabled):
                 self.logger.error("Timekeeping error! Disabling Ethernet")
                 disabled = True
                 self.disable_tx()
                 if self.redis_obj is not None:
                     self.redis_obj.publish(rc, f"Timekeeping error on {self.fpga.antname}. Disabling")
-            if ok and disabled:
-                fpga.logger.warning("Timekeeping recovery! Enabling Ethernet")
+            if test or (ok and disabled):
+                self.logger.warning("Timekeeping recovery! Enabling Ethernet")
                 disabled = False
                 self.enable_tx()
                 if self.redis_obj is not None:

--- a/software/control_sw/src/cosmic_fengine.py
+++ b/software/control_sw/src/cosmic_fengine.py
@@ -1335,28 +1335,6 @@ class CosmicFengine():
             self.logger.warn("Rearming as tt_of_sync %d %% %d != 0" % (self.sync.get_tt_of_sync(), (NTIME_PACKET*FPGA_CLOCKS_PER_SPECTRA)))
 
             rearm_limit -= 1
-            
-
-
-    def set_lo_delays(self, lo_delay_list, force=False):
-        '''
-        Sets the LO Delays.
-        
-        :param lo_delay_list: list of delay in samples to apply in order of streams.
-        :type lo_delay_list: List
-        
-        :param force: If True, call delay.force_load().
-        :type sw_sync: bool
-
-        :return:  Returns the lo_delay values from the board in samples
-        '''
-        for stream, delay in enumerate(lo_delay_list):
-            self.delay.set_delay(stream, delay, force=force)
-
-        return [
-            self.delay.get_delay(stream)
-            for stream, _ in enumerate(lo_delay_list)
-        ]
 
     def read_chan_dest_ips_as_json(self, portnum):
         '''

--- a/software/control_sw/src/cosmic_fengine.py
+++ b/software/control_sw/src/cosmic_fengine.py
@@ -1316,43 +1316,6 @@ class CosmicFengine():
         '''
         return [eth.get_packet_rate() for eth in self.eths]
 
-    def set_lo_frequency_shift(self, lo_fshift_list, sw_sync=False):
-        '''
-        Sets the LO Frequency Shifts and resyncs, disabling tx for the duration of the function.
-        
-        :param lo_fshift_list: list of lo_fshifts in Hz to apply in order of streams.
-        :type lo_fshift_list: List
-        
-        :param sw_sync: If True, issue a software reset trigger, rather than waiting
-            for an external reset pulse to be received over SMA.
-        :type sw_sync: bool
-
-        :return:  Returns the lo_frequency_shift values from the board in Hz
-        '''
-        tx_enabled_mask = self.tx_enabled()
-        self.disable_tx()
-
-        for stream, offshift in enumerate(lo_fshift_list):
-            self.lo.set_lo_frequency_shift(stream, offshift)
-        self.lo.force_load()
-
-        # self.logger.info("Arming sync generators")
-        # self.sync.arm_sync()        
-        # if sw_sync:
-        #     self.logger.info("Issuing software sync")
-        #     self.sync.sw_sync()
-        # else:          
-        self._enforce_valid_tt_armed()
-
-        for i, eth in enumerate(self.eths):
-            if tx_enabled_mask[i]:
-                eth.enable_tx()
-
-        return [
-            self.lo.get_lo_frequency_shift(i, return_in_hz=True)
-            for i in range(len(lo_fshift_list))
-        ]
-
     def _enforce_valid_tt_armed(self, rearm_limit=5, rearm_noise=False):
         '''
         Awaits a sync pulse and validates the telescope-time, re-arming and repeating if it's invalid.

--- a/software/control_sw/src/cosmic_fengine.py
+++ b/software/control_sw/src/cosmic_fengine.py
@@ -1164,13 +1164,13 @@ class CosmicFengine():
                 if self.delay_track.is_set():
                     loadtime_diff_modeltime = (t_future_seconds - delay_coeffs["time_value"])
 
-                    # T = ax^2 + bx + c + delay_calibrations
-                    delay_to_load = (np.array([delay_coeffs["delay_raterate_nsps2"]*(loadtime_diff_modeltime**2) + 
+                    # T = 1/2*ax^2 + bx + c + delay_calibrations
+                    delay_to_load = (np.array([0.5*delay_coeffs["delay_raterate_nsps2"]*(loadtime_diff_modeltime**2) + 
                                         delay_coeffs["delay_rate_nsps"]*loadtime_diff_modeltime + 
                                         delay_coeffs["delay_ns"]]*self.delay.n_streams,dtype=float) +
                                         delay_calib)
-                    # dT/dt = 2ax + b
-                    delay_rate_to_load = np.array([delay_coeffs["delay_raterate_nsps2"]*2*loadtime_diff_modeltime + 
+                    # dT/dt = ax + b
+                    delay_rate_to_load = np.array([delay_coeffs["delay_raterate_nsps2"]*loadtime_diff_modeltime + 
                                             delay_coeffs["delay_rate_nsps"]]*self.delay.n_streams,dtype=float)
 
                     #phase (calculated per tuning)

--- a/software/control_sw/src/cosmic_fengine.py
+++ b/software/control_sw/src/cosmic_fengine.py
@@ -765,7 +765,10 @@ class CosmicFengine():
         self.logger.debug("Channels to send by FID: %s" % (str(channels_to_send_by_fid)))
         self.logger.debug("Largest number of chans with one destination: %d" % channels_to_send)
 
-        pkt_starts, pkt_payloads, word_indices, antchans = self.packetizers[0].get_packet_info(chans_per_packet, channels_to_send, ninput)
+        self.logger.debug("Channel block size: %d" % self.chanreorder.n_parallel_chans)
+        pkt_starts, pkt_payloads, word_indices, antchans = self.packetizers[0].get_packet_info(chans_per_packet, channels_to_send, ninput, chan_block_size=self.chanreorder.n_parallel_chans)
+        for i in range(len(pkt_starts)):
+            self.logger.debug("start %s, payload %s, word_indices %s, antchans %s" % (str(pkt_starts[i]), str(pkt_payloads[i]), str(word_indices[i]), str(antchans[i])))
         n_pkts = len(pkt_starts)
         antchan_indices = np.arange(n_pkts*chans_per_packet, dtype=int)[::chans_per_packet]
         chan_indices = antchan_indices % channels_to_send


### PR DESCRIPTION
DTS related changes:
 - Add `sync` methods to check offset from NTP, and overall "look OK" state
 - Add `CosmicFengine` method to constantly check DTS state, and disable ethernet outputs if it looks bad
 - Add `CosmicFengine` methods to start/stop the above thread. Actions are reported to the redis pubsub `FENG_dtsMonitor`

The envisaged use case is, if the DTS initialization passes all current tests and the board is deemed OK, the monitoring thread should be started with `CosmicFengine.start_dts_monitor()`. A board will have its outputs terminated if something looks like it has gone wrong.

Misc other changes:

Remove two methods from `CosmicFengine` for Delay / LO-shift setting which I believe are now superfluous