### PR TITLE
Phase jump fixes

### DIFF
--- a/software/control_sw/src/cosmic_fengine.py
+++ b/software/control_sw/src/cosmic_fengine.py
@@ -905,6 +905,9 @@ class CosmicFengine():
             self.lo.set_target_load_time(int(lo_load_time * FPGA_CLOCK_RATE_HZ), enable_trig=True)
             self.logger.info(f"F-Shift load time set to {time.ctime(lo_load_time)}")
             time.sleep(lo_load_time - (time.time()))
+            fshift_time_to_load = self.lo.get_time_to_load()/FPGA_CLOCK_RATE_HZ
+            assert (np.isclose(fshift_time_to_load, 0.0, atol=1e-3),
+                    f"After sleeping, time to load from the F-Engine {fshift_time_to_load}s is not near zero.")
         else:
             raise RuntimeError("Cannot set F-shift load time for time in the past.")
 

--- a/software/control_sw/src/cosmic_fengine.py
+++ b/software/control_sw/src/cosmic_fengine.py
@@ -1615,6 +1615,7 @@ class CosmicFengine():
             self.delay_halfcal.clear()
             self.delay_halfphase.clear()
             self.delay_halfphasecorrection.clear()
+            self.delay_fullphasecorrection.clear()
             self.delay_track.set()
             self.start_delay_tracking()
             return
@@ -1676,6 +1677,31 @@ class CosmicFengine():
         self.delay_halfoff.clear()
         self.delay_halfcal.clear()
 
+    def get_delay_tracking_mode(self):
+        """
+        Fetches internal delay tracking mode.
+
+        Returns:
+            delay_mode: str: string indicating current delay tracking mode
+        """
+        if self.delay_tracking_switch.is_set():
+            if self.delay_track.is_set():
+                if self.delay_halfoff.is_set():
+                    return "half-off"
+                elif self.delay_halfcal.is_set():
+                    return "half-cal"
+                elif self.delay_halfphase.is_set():
+                    return "half-phase"
+                elif self.delay_halfphasecorrection.is_set():
+                    return "half-corrected-phase"
+                elif self.delay_fullphasecorrection.is_set():
+                    return "full-corrected-phase"
+                else:
+                    return "true"
+            else:
+                return "fixed-only"
+        else:
+            return "false"
 
     #FOR TESTING ONLY
     def set_delay_tracking(self, delays, delay_rates, phases, phase_rates, sideband, fshifts,

--- a/software/control_sw/src/cosmic_fengine.py
+++ b/software/control_sw/src/cosmic_fengine.py
@@ -717,10 +717,6 @@ class CosmicFengine():
         else:
             self.logger.info('Disabling EQ TVGs...')
             self.eqtvg.tvg_disable()
-        
-        #first, load lo_offshifts, assuming those received are in hz:
-        if lo_fshift_list is not None:
-            self.set_lo_fshift_list(lo_fshift_list)
             
         if sync:
             self.logger.info("Arming sync generators")
@@ -733,6 +729,10 @@ class CosmicFengine():
                 self._enforce_valid_tt_armed(rearm_noise=True)
         else:
             self.logger.warn("Absence of sync means lo offshifts will not load...")
+        
+        #first, load lo_offshifts, assuming those received are in hz:
+        if lo_fshift_list is not None:
+            self.set_lo_fshift_list(lo_fshift_list)
 
         for sn, source_ip in enumerate(source_ips):
             if sn >= self.neths:

--- a/software/control_sw/src/cosmic_fengine.py
+++ b/software/control_sw/src/cosmic_fengine.py
@@ -906,7 +906,7 @@ class CosmicFengine():
             self.logger.info(f"F-Shift load time set to {time.ctime(lo_load_time)}")
             time.sleep(lo_load_time - (time.time()))
             fshift_time_to_load = self.lo.get_time_to_load()/FPGA_CLOCK_RATE_HZ
-            assert (np.isclose(fshift_time_to_load, 0.0, atol=1e-3),
+            assert (np.isclose(fshift_time_to_load, 0.0, atol=1e-2),
                     f"After sleeping, time to load from the F-Engine {fshift_time_to_load}s is not near zero.")
         else:
             raise RuntimeError("Cannot set F-shift load time for time in the past.")
@@ -1588,7 +1588,7 @@ class CosmicFengine():
                     assert (feng_time_to_load > 0, f"F-Engine time to load is not positive = {feng_time_to_load}. This means the load will likely be unsuccessful.")
                     time.sleep(expected_sleep_duration)  
                     feng_time_to_load = self.phaserotate.get_time_to_load()/FPGA_CLOCK_RATE_HZ
-                    assert (np.isclose(feng_time_to_load, 0.0, atol=1e-3),
+                    assert (np.isclose(feng_time_to_load, 0.0, atol=1e-2),
                             f"After sleeping, time to load from the F-Engine {feng_time_to_load}s is not near zero.")
                 except ValueError:
                     self.logger.warn(f"""Tried to sleep for negative time.""")


### PR DESCRIPTION
1. Phase correction factor is calculated from loaded fshifts, not those received via the delay model as before. 
2. Delay checking function returns loaded Fshifts for monitoring.
3. Fshift loading occurs after sync in cold_start.
4. An assert is made after fshift loading to ensure that time_to_load ~ 0s -> ensuring fshifts have loaded.